### PR TITLE
stdlib.json.decoder: Hot fix for json decoder

### DIFF
--- a/grumpy-runtime-src/third_party/stdlib/json/decoder.py
+++ b/grumpy-runtime-src/third_party/stdlib/json/decoder.py
@@ -18,8 +18,10 @@ __all__ = ['JSONDecoder']
 FLAGS = re.VERBOSE | re.MULTILINE | re.DOTALL
 
 def _floatconstants():
-    nan, = struct.unpack('>d', b'\x7f\xf8\x00\x00\x00\x00\x00\x00')
-    inf, = struct.unpack('>d', b'\x7f\xf0\x00\x00\x00\x00\x00\x00')
+    nan = struct.unpack('>d', b'\x7f\xf8\x00\x00\x00\x00\x00\x00')
+    inf = struct.unpack('>d', b'\x7f\xf0\x00\x00\x00\x00\x00\x00')
+    nan = nan[0]
+    inf = inf[0]
     return nan, inf, -inf
 
 NaN, PosInf, NegInf = _floatconstants()


### PR DESCRIPTION
``` python
a = (1,)

c, = a
print(type(c))
# should be <type 'int'>
# but <type 'tuple'> on grumpy
```

There is something wrong behavior on the tuple assignment of grumpy.
This PR does not fix the essential problem but fix to use json library.


Updates: #3 