### PR TITLE
Travis CI: language: go --> language: python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
-language: go
-go:
-  - "1.10.x"
+#language: go
+#go:
+#  - "1.10.x"
+
+language: python
+
+addons:  # Add the version of go that we want
+  apt:
+    sources:
+      - sourceline: 'ppa:gophers/archive'
+    update: true
+    packages: golang-1.10-go
 
 matrix:
   include:
@@ -14,6 +23,9 @@ matrix:
           USER_FLAG=""
 
 before_script:
+  #- ${PIP_SUDO} pip install --upgrade pip
+  - PATH=/usr/lib/go-1.10/bin:${PATH}
+  - go version
   - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"  # https://github.com/travis-ci/travis-ci/issues/8920#issuecomment-352661024
 # Run gofmt and lint serially to avoid confusing output. Run tests in parallel
 # for speed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,20 @@ matrix:
         - SUDO="sudo"
           USER_FLAG=""
 
-before_script:
-  #- ${PIP_SUDO} pip install --upgrade pip
+install:  # These commands are done by Travis when language: go
   - PATH=/usr/lib/go-1.10/bin:${PATH}
+  - export GOPATH=$HOME/gopath
+  - export PATH=$HOME/gopath/bin:$PATH
+  - mkdir -p $HOME/gopath/src/github.com/grumpyhome/grumpy
+  - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/grumpyhome/grumpy/
+  - export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/grumpyhome/grumpy
+  - cd $HOME/gopath/src/github.com/grumpyhome/grumpy
+  - go env
   - go version
+  - go get -t -v ./...
+  #- ${PIP_SUDO} pip install --upgrade pip
+
+before_script:
   - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"  # https://github.com/travis-ci/travis-ci/issues/8920#issuecomment-352661024
 # Run gofmt and lint serially to avoid confusing output. Run tests in parallel
 # for speed.


### PR DESCRIPTION
If we can apt-get install __golang-1.10-go__ then we should be able to run tests on multiple versions of Python.