### PR TITLE
Undefined name: exception --> Exception

### DIFF
--- a/grumpy-tools-src/grumpy_tools/vendor/pythonparser/source.py
+++ b/grumpy-tools-src/grumpy_tools/vendor/pythonparser/source.py
@@ -256,7 +256,7 @@ class RewriterConflict(Exception):
 
     def __init__(self, first, second):
         self.first, self.second = first, second
-        exception.__init__(self, "Ranges %s and %s overlap" % (repr(first), repr(second)))
+        Exception.__init__(self, "Ranges %s and %s overlap" % (repr(first), repr(second)))
 
 class Rewriter:
     """


### PR DESCRIPTION
__exception__ (lowercase 'e') is an undefined name in this context while __Exception__ (uppercase 'e') is the superclass.

[flake8](http://flake8.pycqa.org) testing of https://github.com/grumpyhome/grumpy on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./grumpy_tools/vendor/pythonparser/source.py:259:9: F821 undefined name 'exception'
        exception.__init__(self, "Ranges %s and %s overlap" % (repr(first), repr(second)))
        ^
1     F821 undefined name 'exception'
1
```