### PR TITLE
Added support for iter(f, sentinel)

### DIFF
--- a/grumpy-runtime-src/runtime/builtin_types.go
+++ b/grumpy-runtime-src/runtime/builtin_types.go
@@ -106,6 +106,7 @@ var builtinTypes = map[*Type]*builtinTypeInfo{
 	BoolType:                      {init: initBoolType, global: true},
 	ByteArrayType:                 {init: initByteArrayType, global: true},
 	BytesWarningType:              {global: true},
+	callableIteratorType:          {init: initCallableIteratorType},
 	CodeType:                      {},
 	ComplexType:                   {init: initComplexType, global: true},
 	ClassMethodType:               {init: initClassMethodType, global: true},
@@ -472,10 +473,18 @@ func builtinIsSubclass(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseExcept
 }
 
 func builtinIter(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {
-	if raised := checkFunctionArgs(f, "iter", args, ObjectType); raised != nil {
+	argc := len(args)
+	expectedTypes := []*Type{ObjectType, ObjectType}
+	if argc == 1 {
+		expectedTypes = expectedTypes[:1]
+	}
+	if raised := checkFunctionArgs(f, "iter", args, expectedTypes...); raised != nil {
 		return nil, raised
 	}
-	return Iter(f, args[0])
+	if argc == 1 {
+		return Iter(f, args[0])
+	}
+	return IterCallable(f, args[0], args[1])
 }
 
 func builtinLen(f *Frame, args Args, kwargs KWArgs) (*Object, *BaseException) {

--- a/grumpy-runtime-src/runtime/callableiter.go
+++ b/grumpy-runtime-src/runtime/callableiter.go
@@ -46,6 +46,7 @@ func callableIteratorIter(f *Frame, o *Object) (*Object, *BaseException) {
 func callableIteratorNext(f *Frame, o *Object) (item *Object, raised *BaseException) {
 	i := toCallableIteratorUnsafe(o)
 	i.mutex.Lock()
+	defer i.mutex.Unlock()
 	if i.callable == nil {
 		raised = f.Raise(StopIterationType.ToObject(), nil, nil)
 	} else if item, raised = i.callable.Call(f, Args{}, nil); raised == nil {
@@ -56,7 +57,6 @@ func callableIteratorNext(f *Frame, o *Object) (item *Object, raised *BaseExcept
 			raised = f.Raise(StopIterationType.ToObject(), nil, nil)
 		}
 	}
-	i.mutex.Unlock()
 	return item, raised
 }
 

--- a/grumpy-runtime-src/runtime/callableiter.go
+++ b/grumpy-runtime-src/runtime/callableiter.go
@@ -1,0 +1,67 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grumpy
+
+import (
+	"reflect"
+	"sync"
+)
+
+var (
+	callableIteratorType = newBasisType("callable-iterator", reflect.TypeOf(callableIterator{}), toCallableIteratorUnsafe, ObjectType)
+)
+
+type callableIterator struct {
+	Object
+	callable *Object
+	sentinel *Object
+	mutex    sync.Mutex
+}
+
+func newCallableIterator(callable *Object, sentinel *Object) *Object {
+	iter := &callableIterator{Object: Object{typ: callableIteratorType}, callable: callable, sentinel: sentinel}
+	return &iter.Object
+}
+
+func toCallableIteratorUnsafe(o *Object) *callableIterator {
+	return (*callableIterator)(o.toPointer())
+}
+
+func callableIteratorIter(f *Frame, o *Object) (*Object, *BaseException) {
+	return o, nil
+}
+
+func callableIteratorNext(f *Frame, o *Object) (item *Object, raised *BaseException) {
+	i := toCallableIteratorUnsafe(o)
+	i.mutex.Lock()
+	if i.callable == nil {
+		raised = f.Raise(StopIterationType.ToObject(), nil, nil)
+	} else if item, raised = i.callable.Call(f, Args{}, nil); raised == nil {
+		var eq *Object
+		if eq, raised = Eq(f, item, i.sentinel); raised == nil && eq == True.ToObject() {
+			i.callable = nil
+			item = nil
+			raised = f.Raise(StopIterationType.ToObject(), nil, nil)
+		}
+	}
+	i.mutex.Unlock()
+	return item, raised
+}
+
+func initCallableIteratorType(map[string]*Object) {
+	callableIteratorType.flags &= ^(typeFlagBasetype | typeFlagInstantiable)
+	callableIteratorType.slots.Iter = &unaryOpSlot{callableIteratorIter}
+	callableIteratorType.slots.Next = &unaryOpSlot{callableIteratorNext}
+}

--- a/grumpy-runtime-src/runtime/callableiter_test.go
+++ b/grumpy-runtime-src/runtime/callableiter_test.go
@@ -1,0 +1,44 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grumpy
+
+import (
+	"testing"
+)
+
+func TestCallableIterator(t *testing.T) {
+	fun := newBuiltinFunction("TestCallableIterator", func(f *Frame, args Args, _ KWArgs) (*Object, *BaseException) {
+		return TupleType.Call(f, args, nil)
+	}).ToObject()
+	makeCounter := func() *Object {
+		cnt := 0
+		return newBuiltinFunction("counter", func(f *Frame, _ Args, _ KWArgs) (*Object, *BaseException) {
+			cnt++
+			return NewInt(cnt).ToObject(), nil
+		}).ToObject()
+	}
+	exhaustedIter := newCallableIterator(makeCounter(), NewInt(2).ToObject())
+	TupleType.Call(NewRootFrame(), []*Object{exhaustedIter}, nil)
+	cases := []invokeTestCase{
+		{args: wrapArgs(newCallableIterator(makeCounter(), NewInt(4).ToObject())), want: newTestTuple(1, 2, 3).ToObject()},
+		{args: wrapArgs(newCallableIterator(makeCounter(), NewInt(1).ToObject())), want: newTestTuple().ToObject()},
+		{args: wrapArgs(exhaustedIter), want: NewTuple().ToObject()},
+	}
+	for _, cas := range cases {
+		if err := runInvokeTestCase(fun, &cas); err != "" {
+			t.Error(err)
+		}
+	}
+}


### PR DESCRIPTION
To support the `sentinel` variant of `iter`, a new iterator type had to be added: `callableIterator`. I'm not completely happy that I had to put it in its own file (callableiter.go), but I did not find a suitable place for it (core.go was a candidate, but it does not really define types).