### PR TITLE
Fixes #109: Imports raising AttributeError instead of ImportError

### DIFF
--- a/grumpy-runtime-src/runtime/core.go
+++ b/grumpy-runtime-src/runtime/core.go
@@ -256,6 +256,17 @@ func GetAttr(f *Frame, o *Object, name *Str, def *Object) (*Object, *BaseExcepti
 	return result, raised
 }
 
+// GetAttrImport behaves as GetAttr, but errors raises ImportError instead of
+// AttributeError
+func GetAttrImport(f *Frame, o *Object, name *Str) (*Object, *BaseException) {
+	result, raised := GetAttr(f, o, name, nil)
+	if raised != nil && raised.isInstance(AttributeErrorType) {
+		msg := fmt.Sprintf("cannot import name %s", name.Value())
+		return nil, f.RaiseType(ImportErrorType, msg)
+	}
+	return result, raised
+}
+
 // GT returns the result of operation v > w.
 func GT(f *Frame, v, w *Object) (*Object, *BaseException) {
 	r, raised := compareRich(f, compareOpGT, v, w)

--- a/grumpy-runtime-src/runtime/module.go
+++ b/grumpy-runtime-src/runtime/module.go
@@ -123,7 +123,8 @@ func importOne(f *Frame, name string) (*Object, *BaseException) {
 	o, raised := SysModules.GetItemString(f, name)
 	if raised == nil && o == nil {
 		if c = moduleRegistry[name]; c == nil {
-			raised = f.RaiseType(ImportErrorType, name)
+			msg := fmt.Sprintf("No module named %s", name)
+			raised = f.RaiseType(ImportErrorType, msg)
 		} else {
 			o = newModule(name, c.filename).ToObject()
 			raised = SysModules.SetItemString(f, name, o)

--- a/grumpy-runtime-src/runtime/module_test.go
+++ b/grumpy-runtime-src/runtime/module_test.go
@@ -79,7 +79,7 @@ func TestImportModule(t *testing.T) {
 		{
 			"noexist",
 			nil,
-			mustCreateException(ImportErrorType, "noexist"),
+			mustCreateException(ImportErrorType, "No module named noexist"),
 			newStringDict(map[string]*Object{"invalid": invalidModule}),
 		},
 		{

--- a/grumpy-tools-src/grumpy_tools/compiler/imputil.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/imputil.py
@@ -98,7 +98,8 @@ class Importer(algorithm.Visitor):
         asname = alias.asname if alias.asname else alias.name.split('/')[-1]
         imp.add_binding(Import.MODULE, asname, 0)
       else:
-        imp = self._resolve_import(node, alias.name)
+        imp = self._resolve_import(node, alias.name, allow_error=True)
+
         if alias.asname:
           imp.add_binding(Import.MODULE, alias.asname, imp.name.count('.'))
         else:
@@ -155,7 +156,7 @@ class Importer(algorithm.Visitor):
         imports.append(imp)
     return imports
 
-  def _resolve_import(self, node, modname):
+  def _resolve_import(self, node, modname, allow_error=False):
     if not self.absolute_import and self.package_dir:
       script = find_script(self.package_dir, modname)
       if script:
@@ -164,6 +165,8 @@ class Importer(algorithm.Visitor):
       script = find_script(dirname, modname)
       if script:
         return Import(modname, script)
+    if allow_error:
+      return Import(modname, '')
     raise util.ImportError(node, 'no such module: {} (script: {})'.format(modname, self.script))
 
   def _resolve_relative_import(self, level, node, modname):

--- a/grumpy-tools-src/grumpy_tools/compiler/imputil_test.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/imputil_test.py
@@ -81,11 +81,6 @@ class ImportVisitorTest(unittest.TestCase):
   def tearDown(self):
     shutil.rmtree(self.rootdir)
 
-  def testImportEmptyPath(self):
-    importer = imputil.Importer(None, 'foo', 'foo.py', False)
-    self.assertRaises(util.ImportError, importer.visit,
-                      pythonparser.parse('import bar').body[0])
-
   def testImportTopLevelModule(self):
     imp = copy.deepcopy(self.qux_import)
     imp.add_binding(imputil.Import.MODULE, 'qux', 0)

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt.py
@@ -637,7 +637,7 @@ class StatementVisitor(algorithm.Visitor):
           # Binding a member of the imported module.
           with self.block.alloc_temp() as member:
             self.writer.write_checked_call2(
-                member, 'πg.GetAttr(πF, {}, {}, nil)',
+                member, 'πg.GetAttrImport(πF, {}, {})',
                 mod.expr, self.block.root.intern(binding.value))
             self.block.bind_var(self.writer, binding.alias, member.expr)
 

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt.py
@@ -631,7 +631,7 @@ class StatementVisitor(algorithm.Visitor):
           self.block.bind_var(self.writer, binding.alias, mod.expr)
         elif binding.bind_type == imputil.Import.STAR:
           self.writer.write_checked_call1('πg.LoadMembers(πF, {}[0])', mod_slice.name)
-        else:
+        else:  # Import.MEMBER
           self.writer.write('{} = {}[{}]'.format(
               mod.name, mod_slice.expr, imp.name.count('.')))
           # Binding a member of the imported module.

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
@@ -355,7 +355,7 @@ class StatementVisitorTest(unittest.TestCase):
         print inexistantmodule
     """))
     self.assertEqual(0, result[0])
-    self.assertIn('<function inexistantmodule at', result[1])
+    self.assertIn('<function sleep at', result[1])
 
   def testImportFromTryExcept(self):
     result = _GrumpRun(textwrap.dedent("""\

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
@@ -346,6 +346,17 @@ class StatementVisitorTest(unittest.TestCase):
     self.assertEqual(0, result[0])
     self.assertIn('<function sleep at', result[1])
 
+  def testImportTryExcept(self):
+    result = _GrumpRun(textwrap.dedent("""\
+        try:
+          import inexistantmodule
+        except ImportError:
+          from time import sleep as inexistantmodule
+        print inexistantmodule
+    """))
+    self.assertEqual(0, result[0])
+    self.assertIn('<function inexistantmodule at', result[1])
+
   def testImportFromTryExcept(self):
     result = _GrumpRun(textwrap.dedent("""\
         try:

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
@@ -346,6 +346,17 @@ class StatementVisitorTest(unittest.TestCase):
     self.assertEqual(0, result[0])
     self.assertIn('<function sleep at', result[1])
 
+  def testImportFromTryExcept(self):
+    result = _GrumpRun(textwrap.dedent("""\
+        try:
+          from time import inexistantfunction
+        except ImportError:
+          from time import sleep
+        print sleep
+    """))
+    self.assertEqual(0, result[0])
+    self.assertIn('<function sleep at', result[1])
+
   def testPrintFunction(self):
     want = "abc\n123\nabc 123\nabcx123\nabc 123 "
     self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\

--- a/grumpy-tools-src/grumpy_tools/grumpc.py
+++ b/grumpy-tools-src/grumpy_tools/grumpc.py
@@ -101,6 +101,9 @@ def _collect_deps(script, modname, pep3147_folders, from_cache=False, update_cac
 def _recursively_transpile(import_objects):
   for imp_obj in import_objects:
     if not imp_obj.is_native:
+      if not imp_obj.script:
+        continue  # Let the ImportError raise on run time
+
       # Recursively compile the discovered imports
       # TODO: Fix cyclic imports?
       name = imp_obj.name[1:] if imp_obj.name.startswith('.') else imp_obj.name

--- a/grumpy-tools-src/grumpy_tools/pydeps.py
+++ b/grumpy-tools-src/grumpy_tools/pydeps.py
@@ -40,6 +40,9 @@ def main(script=None, modname=None, package_dir='', with_imports=False):
       if imp.is_native and imp.name:
         yield imp.name
       else:
+        if not imp.script:
+          continue  # Let the ImportError raise on run time
+
         parts = imp.name.split('.')
         # Iterate over all packages and the leaf module.
         for i in xrange(len(parts)):


### PR DESCRIPTION
Fixes #109.

Importing `from time import wrongmember` raises ImportError as CPython, not AttributeError.
Importing `import wrongmodule` raises ImportError on runtime as CPython, not grumpy_tools.compiler.util.ImportError on compile time