### PR TITLE
[Fix #114] `go get golint` is failing

### DIFF
--- a/grumpy-runtime-src/Makefile
+++ b/grumpy-runtime-src/Makefile
@@ -237,7 +237,7 @@ gofmt: build/gofmt.diff
 	@if [ -s $< ]; then echo 'gofmt found errors, run: gofmt -w $(ROOT_DIR)/runtime/*.go'; false; fi
 
 $(GOLINT_BIN):
-	@go get -u github.com/golang/lint/golint
+	@go get -u golang.org/x/lint/golint
 
 golint: $(GOLINT_BIN)
 	@$(GOLINT_BIN) -set_exit_status runtime


### PR DESCRIPTION
As said in https://github.com/golang/lint/issues/415, `golint` should be installed from `golang.org/x/lint/golint` instead of `github.com/golang/lint/golint`

This PR fixes #114 