### PR TITLE
Allow code that uses `exec` to fail on run time instead of compile time

### DIFF
--- a/grumpy-tools-src/grumpy_tools/compiler/stmt.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt.py
@@ -191,7 +191,7 @@ class StatementVisitor(algorithm.Visitor):
 
   def visit_Exec(self, node):
     self._write_py_context(node.lineno)
-    self.writer.write('πE = πF.RaiseType(πg.NotImplementedErrorType, exec is not available on Grumpy. Maybe never be.")')
+    self.writer.write('πE = πF.RaiseType(πg.NotImplementedErrorType, "exec is not available on Grumpy. Maybe never be.")')
     self.writer.write('continue')
 
   def visit_Expr(self, node):

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt.py
@@ -189,6 +189,11 @@ class StatementVisitor(algorithm.Visitor):
         msg = 'del target not implemented: {}'.format(type(target).__name__)
         raise util.ParseError(node, msg)
 
+  def visit_Exec(self, node):
+    self._write_py_context(node.lineno)
+    self.writer.write('πE = πF.RaiseType(πg.NotImplementedErrorType, exec is not available on Grumpy. Maybe never be.")')
+    self.writer.write('continue')
+
   def visit_Expr(self, node):
     self._write_py_context(node.lineno)
     self.visit_expr(node.value).free()


### PR DESCRIPTION
On the same spirit of #118, simple having a code that have `exec` on it does not mean that it will be called. Should compile and maybe raise a `NotImplementedError` on runtime, if called.

```python
try:
    from math import sum
except ImportError:
    exec '2+2'
```

and:

```bash
$ grumpy -c 'exec "2+2"'
Traceback (most recent call last):
  File "/Users/alanjds/src/git/grumpy/grumpy-tools-src/__main__.py", line 1, in <module>
NotImplementedError: exec is not available on Grumpy. Maybe never be.
```