### PR TITLE
Go keywords on Python module names are changed to not clash

### DIFF
--- a/grumpy-tools-src/grumpy_tools/grumpc.py
+++ b/grumpy-tools-src/grumpy_tools/grumpc.py
@@ -34,7 +34,7 @@ from .compiler import imputil
 from .compiler import stmt
 from .compiler import util
 from .vendor import pythonparser
-from .pep_support.pep3147pycache import make_transpiled_module_folders, should_refresh, set_checksum
+from .pep_support.pep3147pycache import make_transpiled_module_folders, should_refresh, set_checksum, fixed_keyword
 from . import pydeps
 
 logger = logging.getLogger(__name__)
@@ -134,7 +134,7 @@ def _transpile(script, modname, imports, visitor, mod_block):
       \tCode = πg.NewCode("<module>", $script, nil, 0, func(πF *πg.Frame, _ []*πg.Object) (*πg.Object, *πg.BaseException) {
       \t\tvar πR *πg.Object; _ = πR
       \t\tvar πE *πg.BaseException; _ = πE""")
-  writer.write_tmpl(tmpl, package=modname.split('.')[-1],
+  writer.write_tmpl(tmpl, package=fixed_keyword(modname.split('.')[-1]),
                     script=util.go_str(script), imports=imports)
   with writer.indent_block(2):
     for s in sorted(mod_block.strings):
@@ -195,7 +195,7 @@ def main(stream=None, modname=None, pep3147=False, recursive=False, return_resul
 def _package_name(modname):
   if modname.startswith('__go__/'):
     return '__python__/' + modname
-  return '__python__/' + modname.replace('.', '/')
+  return '__python__/' + fixed_keyword(modname).replace('.', '/')
 
 
 def _get_parent_packages(modname):

--- a/grumpy-tools-src/grumpy_tools/grumprun.py
+++ b/grumpy-tools-src/grumpy_tools/grumprun.py
@@ -117,8 +117,8 @@ def main(stream=None, modname=None, pep3147=False, clean_tempfolder=True):
     # Make sure traceback is available in all Python binaries.
     names = set(['traceback'])
     go_main = os.path.join(workdir, 'main.go')
-    package = _package_name(modname)
-    imports = ''.join('\t_ "' + _package_name(name) + '"\n' for name in names)
+    package = grumpc._package_name(modname)
+    imports = ''.join('\t_ "' + grumpc._package_name(name) + '"\n' for name in names)
     with open(go_main, 'w') as f:
       f.write(module_tmpl.substitute(package=package, imports=imports))
     logger.info('`go run` GOPATH=%s', os.environ['GOPATH'])
@@ -130,9 +130,3 @@ def main(stream=None, modname=None, pep3147=False, clean_tempfolder=True):
         shutil.rmtree(pep3147_folders['cache_folder'], ignore_errors=True)
       else:
         logger.warning('not cleaning the temporary pycache folder: %s', pep3147_folders['cache_folder'])
-
-
-def _package_name(modname):
-  if modname.startswith('__go__/'):
-    return '__python__/' + modname
-  return '__python__/' + modname.replace('.', '/')

--- a/grumpy-tools-src/grumpy_tools/pep_support/pep3147pycache.py
+++ b/grumpy-tools-src/grumpy_tools/pep_support/pep3147pycache.py
@@ -22,6 +22,15 @@ TRANSPILED_MODULES_FOLDER = 'src/__python__/'
 GRUMPY_MAGIC_TAG = 'grumpy-' + grumpy_tools.__version__.replace('.', '')  # alike cpython-27
 ORIGINAL_MAGIC_TAG = sys.implementation.cache_tag  # On Py27, only because importlib2
 
+# See: https://golang.org/ref/spec#Keywords
+_GO_RESERVED_KEYWORDS = {
+  'break',        'default',      'func',         'interface',    'select',
+  'case',         'defer',        'go',           'map',          'struct',
+  'chan',         'else',         'goto',         'package',      'switch',
+  'const',        'fallthrough',  'if',           'range',        'type',
+  'continue',     'for',          'import',       'return',       'var',
+}
+
 _temporary_directories = []  # Will be cleaned up on main Python exit.
 
 
@@ -172,7 +181,7 @@ def make_transpiled_module_folders(script_path, module_name):
         'cache_folder': get_pycache_folder(script_path, module_name),
         'gopath_folder': get_gopath_folder(script_path, module_name),
         'transpiled_base_folder': get_transpiled_base_folder(script_path, module_name),
-        'transpiled_module_folder': get_transpiled_module_folder(script_path, module_name),
+        'transpiled_module_folder': get_transpiled_module_folder(script_path, fixed_keyword(module_name)),
     }
     for role, folder in needed_folders.items():
         if os.path.isfile(folder):  # 1. Need a folder. Remove the file
@@ -205,3 +214,13 @@ def _maybe_link_paths(orig, dest):
             logger.debug('Linked %s to %s', orig, dest)
             return True
     return False
+
+
+def fixed_keyword(keyword):
+  """
+  Go have some reserved words that could be Python module names. This modules
+  needs to be renamed at least on "naked" Go code, e.g. `package` definition
+  """
+  if keyword in _GO_RESERVED_KEYWORDS:
+    return keyword + '_goreservedkeyword'
+  return keyword

--- a/grumpy-tools-src/grumpy_tools/pep_support/pep3147pycache.py
+++ b/grumpy-tools-src/grumpy_tools/pep_support/pep3147pycache.py
@@ -139,6 +139,7 @@ def get_transpiled_base_folder(script_path, module_name):
 
 
 def get_transpiled_module_folder(script_path, module_name):
+    module_name = fixed_keyword(module_name)
     transpiled_base_folder = get_transpiled_base_folder(script_path, module_name)
     parts = module_name.split('.')
     return os.path.join(transpiled_base_folder, *parts)
@@ -181,7 +182,7 @@ def make_transpiled_module_folders(script_path, module_name):
         'cache_folder': get_pycache_folder(script_path, module_name),
         'gopath_folder': get_gopath_folder(script_path, module_name),
         'transpiled_base_folder': get_transpiled_base_folder(script_path, module_name),
-        'transpiled_module_folder': get_transpiled_module_folder(script_path, fixed_keyword(module_name)),
+        'transpiled_module_folder': get_transpiled_module_folder(script_path, module_name),
     }
     for role, folder in needed_folders.items():
         if os.path.isfile(folder):  # 1. Need a folder. Remove the file

--- a/grumpy-tools-src/grumpy_tools/pep_support/pep3147pycache.py
+++ b/grumpy-tools-src/grumpy_tools/pep_support/pep3147pycache.py
@@ -29,7 +29,7 @@ _GO_RESERVED_KEYWORDS = {
   'chan',         'else',         'goto',         'package',      'switch',
   'const',        'fallthrough',  'if',           'range',        'type',
   'continue',     'for',          'import',       'return',       'var',
-}
+}.union(['main'])  # Found to be troublesome as module names
 
 _temporary_directories = []  # Will be cleaned up on main Python exit.
 

--- a/grumpy-tools-src/grumpy_tools/pep_support/pep3147pycache.py
+++ b/grumpy-tools-src/grumpy_tools/pep_support/pep3147pycache.py
@@ -216,11 +216,17 @@ def _maybe_link_paths(orig, dest):
     return False
 
 
-def fixed_keyword(keyword):
-  """
-  Go have some reserved words that could be Python module names. This modules
-  needs to be renamed at least on "naked" Go code, e.g. `package` definition
-  """
-  if keyword in _GO_RESERVED_KEYWORDS:
-    return keyword + '_goreservedkeyword'
-  return keyword
+def fixed_keyword(keyword, split='.'):
+    """
+    Go have some reserved words that could be Python module names. This modules
+    needs to be renamed at least on "naked" Go code, e.g. `package` definition
+    """
+    if split:
+        keys = keyword.split(split)
+    else:
+        keys = [keyword]
+
+    for i, kw in enumerate(keys):
+        if kw in _GO_RESERVED_KEYWORDS:
+            keys[i] += '_goreservedkeyword'
+    return split.join(keys)


### PR DESCRIPTION
Fixes #124

The module `struct` still does not compile, but is because `_struct` is a C module, not because its name is not compatible with Grumpy way to deal with Go.