### PR TITLE
Grumpy' stdlib have preference over CPython' stdlib

### DIFF
--- a/grumpy-tools-src/grumpy_tools/compiler/imputil.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/imputil.py
@@ -283,7 +283,7 @@ def calculate_transitive_deps(modname, script, gopath):
 
 
 def find_script(dirname, name, main=False, use_grumpy_stdlib=True):
-  if use_grumpy_stdlib and dirname in _CPYTHON_STDLIB_PATHS:
+  if use_grumpy_stdlib and _GRUMPY_STDLIB_PATH and dirname in _CPYTHON_STDLIB_PATHS:
     # Grumpy stdlib have preference over CPython stdlib
     result = find_script(_GRUMPY_STDLIB_PATH, name, main=main, use_grumpy_stdlib=False)
     if result:


### PR DESCRIPTION
This is needed when a CPython stdlib module tries to import another. E.g. `zipfile` imports `os`:

Should be provided the Grumpy `os` module but there is an `os.py` on the same folder of stdlib `zipfile.py`.