### PR TITLE
Pep 257: docstrings

### DIFF
--- a/grumpy-runtime-src/runtime/function.go
+++ b/grumpy-runtime-src/runtime/function.go
@@ -89,7 +89,10 @@ type Function struct {
 // number of arguments are provided, populating *args and **kwargs if
 // necessary, etc.
 func NewFunction(c *Code, globals *Dict) *Function {
-	return &Function{Object{typ: FunctionType, dict: NewDict()}, nil, c.name, c, globals}
+	d := newStringDict(map[string]*Object{
+		"__doc__": None,
+	})
+	return &Function{Object{typ: FunctionType, dict: d}, nil, c.name, c, globals}
 }
 
 // newBuiltinFunction returns a function object with the given name that

--- a/grumpy-runtime-src/runtime/method.go
+++ b/grumpy-runtime-src/runtime/method.go
@@ -123,7 +123,11 @@ func methodNew(f *Frame, t *Type, args Args, _ KWArgs) (*Object, *BaseException)
 	if raised != nil {
 		return nil, raised
 	}
-	method := &Method{Object{typ: MethodType}, function, self, class, functionName}
+
+	d := newStringDict(map[string]*Object{
+		"__doc__": None,
+	})
+	method := &Method{Object{typ: MethodType, dict: d}, function, self, class, functionName}
 	return method.ToObject(), nil
 }
 

--- a/grumpy-runtime-src/runtime/module.go
+++ b/grumpy-runtime-src/runtime/module.go
@@ -244,6 +244,7 @@ func newModule(name, filename string) *Module {
 		"__file__":    NewStr(filename).ToObject(),
 		"__name__":    NewStr(name).ToObject(),
 		"__package__": NewStr(pkgName).ToObject(),
+		"__doc__":     None,
 	})
 	return &Module{Object: Object{typ: ModuleType, dict: d}}
 }

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt.py
@@ -53,12 +53,18 @@ class StatementVisitor(algorithm.Visitor):
     self.future_node = future_node
     self.writer = util.Writer()
     self.expr_visitor = expr_visitor.ExprVisitor(self)
+    self.docstring = None
 
   def generic_visit(self, node):
     msg = 'node not yet implemented: {}'.format(type(node).__name__)
     raise util.ParseError(node, msg)
 
   def visit_expr(self, node):
+    # Collect the 1st module string as docstring (<module>.__doc__)
+    if self.docstring is None and isinstance(node, ast.Str):
+      self.docstring = node
+      doc_assign = ast.Assign(loc=node.loc, targets=[ast.Name(id='__doc__')], value=node)
+      self.visit_Assign(doc_assign)
     return self.expr_visitor.visit(node)
 
   def visit_Assert(self, node):

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt.py
@@ -53,7 +53,7 @@ class StatementVisitor(algorithm.Visitor):
     self.future_node = future_node
     self.writer = util.Writer()
     self.expr_visitor = expr_visitor.ExprVisitor(self)
-    self.docstring = None
+    self._docstring = None
 
   def generic_visit(self, node):
     msg = 'node not yet implemented: {}'.format(type(node).__name__)
@@ -61,12 +61,12 @@ class StatementVisitor(algorithm.Visitor):
 
   def visit_expr(self, node):
     # Collect the 1st module string as docstring (<module>.__doc__)
-    if self.docstring is None and isinstance(node, ast.Str):
+    if self._docstring is None and isinstance(node, ast.Str):
       self._assign_docstring(node)
     return self.expr_visitor.visit(node)
 
   def _assign_docstring(self, node):
-    self.docstring = node
+    self._docstring = node
     if isinstance(self.block, block.FunctionBlock):
       ## function name <- self.block.name
       ## class or module of such function <- self.block.parent

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt.py
@@ -62,10 +62,24 @@ class StatementVisitor(algorithm.Visitor):
   def visit_expr(self, node):
     # Collect the 1st module string as docstring (<module>.__doc__)
     if self.docstring is None and isinstance(node, ast.Str):
-      self.docstring = node
-      doc_assign = ast.Assign(loc=node.loc, targets=[ast.Name(id='__doc__')], value=node)
-      self.visit_Assign(doc_assign)
+      self._assign_docstring(node)
     return self.expr_visitor.visit(node)
+
+  def _assign_docstring(self, node):
+    self.docstring = node
+    if isinstance(self.block, block.FunctionBlock):
+      ## function name <- self.block.name
+      ## class or module of such function <- self.block.parent
+      ## Best guess:
+      # doc_assign = ast.Assign(
+      #   loc=node.loc,
+      #   targets=[ast.Attribute(value=ast.Name(id=self.block.name), attr='__doc__')],
+      #   value=node,
+      # )
+      return # TODO: Handle function docstrings
+
+    doc_assign = ast.Assign(loc=node.loc, targets=[ast.Name(id='__doc__')], value=node)
+    self.visit_Assign(doc_assign)
 
   def visit_Assert(self, node):
     self._write_py_context(node.lineno)

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 
 import string
 import textwrap
+from itertools import ifilter
 
 from grumpy_tools.compiler import block
 from grumpy_tools.compiler import expr
@@ -62,22 +63,12 @@ class StatementVisitor(algorithm.Visitor):
   def visit_expr(self, node):
     # Collect the 1st module string as docstring (<module>.__doc__)
     if self._docstring is None and isinstance(node, ast.Str):
-      self._assign_docstring(node)
+      if not isinstance(self.block, block.FunctionBlock):
+        self._assign_docstring(node)
     return self.expr_visitor.visit(node)
 
   def _assign_docstring(self, node):
     self._docstring = node
-    if isinstance(self.block, block.FunctionBlock):
-      ## function name <- self.block.name
-      ## class or module of such function <- self.block.parent
-      ## Best guess:
-      # doc_assign = ast.Assign(
-      #   loc=node.loc,
-      #   targets=[ast.Attribute(value=ast.Name(id=self.block.name), attr='__doc__')],
-      #   value=node,
-      # )
-      return # TODO: Handle function docstrings
-
     doc_assign = ast.Assign(loc=node.loc, targets=[ast.Name(id='__doc__')], value=node)
     self.visit_Assign(doc_assign)
 
@@ -245,6 +236,18 @@ class StatementVisitor(algorithm.Visitor):
     self._write_py_context(node.lineno + len(node.decorator_list))
     func = self.visit_function_inline(node)
     self.block.bind_var(self.writer, node.name, func.expr)
+
+    # Docstring should be the 1st statement (expression), if exists
+    first_expr = node.body[0]
+    if isinstance(first_expr, ast.Expr) and isinstance(first_expr.value, ast.Str):
+      docstring = first_expr.value
+      doc_assign = ast.Assign(
+        loc=docstring.loc,
+        targets=[ast.Attribute(value=ast.Name(id=node.name), attr='__doc__')],
+        value=docstring,
+      )
+      self.visit_Assign(doc_assign)
+
     while node.decorator_list:
       decorator = node.decorator_list.pop()
       wrapped = ast.Name(id=node.name)

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
@@ -405,15 +405,22 @@ class StatementVisitorTest(unittest.TestCase):
         print('abc', 123, end=' ')""")))
 
   def testModuleDocstring(self):
-    want = "__doc__ (unicode) is the module docstring\n"
+    want = "__doc__ (unicode) is module docstring\n"
     self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\
         from __future__ import unicode_literals
         "module docstring"
-        print "__doc__ (" + type(__doc__).__name__ + ") is the " + __doc__"""
+        print "__doc__ (" + type(__doc__).__name__ + ") is " + str(__doc__)"""
+    )))
+
+  def testModuleDocstringAbsent(self):
+    want = "__doc__ (NoneType) is None\n"
+    self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\
+        from __future__ import unicode_literals
+        print "__doc__ (" + type(__doc__).__name__ + ") is " + str(__doc__)"""
     )))
 
   def testClassDocstring(self):
-    want = "Foo.__doc__ (unicode) is the class docstring\n"
+    want = "Foo.__doc__ (unicode) is class docstring\n"
     self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\
         from __future__ import unicode_literals
         "module docstring"
@@ -422,12 +429,25 @@ class StatementVisitorTest(unittest.TestCase):
           "class docstring"
           pass
 
-        print "Foo.__doc__ (" + type(Foo.__doc__).__name__ + ") is the " + Foo.__doc__"""
+        print "Foo.__doc__ (" + type(Foo.__doc__).__name__ + ") is " + str(Foo.__doc__)"""
+    )))
+
+  @pytest.mark.xfail
+  def testClassDocstringAbsent(self):
+    want = "Foo.__doc__ (NoneType) is None\n"
+    self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\
+        from __future__ import unicode_literals
+        "module docstring"
+
+        class Foo(object):
+          pass
+
+        print "Foo.__doc__ (" + type(Foo.__doc__).__name__ + ") is " + str(Foo.__doc__)"""
     )))
 
   @pytest.mark.xfail
   def testFunctionDocstring(self):
-    want = "Foo.func.__doc__ (unicode) is the function docstring\n"
+    want = "Foo.func.__doc__ (unicode) is function docstring\n"
     self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\
         from __future__ import unicode_literals
         "module docstring"
@@ -439,7 +459,22 @@ class StatementVisitorTest(unittest.TestCase):
             "function docstring"
             return
 
-        print "Foo.func.__doc__ (" + type(Foo.__doc__).__name__ + ") is the " + Foo.func.__doc__"""
+        print "Foo.func.__doc__ (" + type(Foo.__doc__).__name__ + ") is " + str(Foo.func.__doc__)"""
+    )))
+
+  def testFunctionDocstringAbsent(self):
+    want = "Foo.func.__doc__ (NoneType) is None\n"
+    self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\
+        from __future__ import unicode_literals
+        "module docstring"
+
+        class Foo(object):
+          "class docstring"
+
+          def func(self):
+            return
+
+        print "Foo.func.__doc__ (" + type(Foo.func.__doc__).__name__ + ") is " + str(Foo.func.__doc__)"""
     )))
 
   def testRaiseExitStatus(self):

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
@@ -31,6 +31,7 @@ from grumpy_tools.compiler import util
 from grumpy_tools.vendor import pythonparser
 from grumpy_tools.vendor.pythonparser import ast
 
+import pytest
 
 class StatementVisitorTest(unittest.TestCase):
 
@@ -409,6 +410,36 @@ class StatementVisitorTest(unittest.TestCase):
         from __future__ import unicode_literals
         "module docstring"
         print "__doc__ (" + type(__doc__).__name__ + ") is the " + __doc__"""
+    )))
+
+  def testClassDocstring(self):
+    want = "Foo.__doc__ (unicode) is the class docstring\n"
+    self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\
+        from __future__ import unicode_literals
+        "module docstring"
+
+        class Foo(object):
+          "class docstring"
+          pass
+
+        print "Foo.__doc__ (" + type(Foo.__doc__).__name__ + ") is the " + Foo.__doc__"""
+    )))
+
+  @pytest.mark.xfail
+  def testFunctionDocstring(self):
+    want = "Foo.func.__doc__ (unicode) is the function docstring\n"
+    self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\
+        from __future__ import unicode_literals
+        "module docstring"
+
+        class Foo(object):
+          "class docstring"
+
+          def func(self):
+            "function docstring"
+            return
+
+        print "Foo.func.__doc__ (" + type(Foo.__doc__).__name__ + ") is the " + Foo.func.__doc__"""
     )))
 
   def testRaiseExitStatus(self):

--- a/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/stmt_test.py
@@ -403,6 +403,14 @@ class StatementVisitorTest(unittest.TestCase):
         print('abc', 123, sep='x')
         print('abc', 123, end=' ')""")))
 
+  def testModuleDocstring(self):
+    want = "__doc__ (unicode) is the module docstring\n"
+    self.assertEqual((0, want), _GrumpRun(textwrap.dedent("""\
+        from __future__ import unicode_literals
+        "module docstring"
+        print "__doc__ (" + type(__doc__).__name__ + ") is the " + __doc__"""
+    )))
+
   def testRaiseExitStatus(self):
     self.assertEqual(1, _GrumpRun('raise Exception')[0])
 


### PR DESCRIPTION
Docstrings are needed for some stdlib modules to be importable. E.g. `struct.py` imports `__doc__` from `_struct.py`, but there the `__doc__` is implicitly assumed as the 1st string statement of the file.

The actual PR assumes every module, class and function/method to start with an empty (`None`) `__doc__`. The AST visitor is told to take the 1st `Str` statement and inject an `__doc__ = <value:str>` "Assign" node.

It works very well for modules and module-level functions, but not for methods. Should be refactored later, maybe to show the `__doc__` as a slot instead of a member of `__dict__` of such function/method