### PR TITLE
Fix circular imports (zipfile.py)

### DIFF
--- a/grumpy-tools-src/grumpy_tools/cli.py
+++ b/grumpy-tools-src/grumpy_tools/cli.py
@@ -47,7 +47,7 @@ def transpile(script=None, modname=None, pep3147=False):
     """
     _ensure_gopath(raises=False)
 
-    output = grumpc.main(stream=script, modname=modname, pep3147=pep3147)
+    output = grumpc.main(stream=script, modname=modname, pep3147=pep3147)['gocode']
     click.echo(output)
     sys.exit(0)
 

--- a/grumpy-tools-src/grumpy_tools/compiler/imputil.py
+++ b/grumpy-tools-src/grumpy_tools/compiler/imputil.py
@@ -28,6 +28,11 @@ import sys
 import sysconfig
 from pkg_resources import resource_filename, Requirement, DistributionNotFound
 
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
+
 from grumpy_tools.compiler import util
 from grumpy_tools.vendor import pythonparser
 from grumpy_tools.vendor.pythonparser import algorithm
@@ -282,6 +287,7 @@ def calculate_transitive_deps(modname, script, gopath):
   return deps
 
 
+@lru_cache()
 def find_script(dirname, name, main=False, use_grumpy_stdlib=True):
   if use_grumpy_stdlib and _GRUMPY_STDLIB_PATH and dirname in _CPYTHON_STDLIB_PATHS:
     # Grumpy stdlib have preference over CPython stdlib

--- a/grumpy-tools-src/grumpy_tools/grumpc.py
+++ b/grumpy-tools-src/grumpy_tools/grumpc.py
@@ -114,10 +114,15 @@ def _recursively_transpile(import_objects, ignore=None):
         continue  # Let the ImportError raise on run time
 
       # Recursively compile the discovered imports
-      main(stream=open(imp_obj.script), modname=name, pep3147=True, recursive=True, return_result=False, ignore=ignore)
+      result = main(stream=open(imp_obj.script), modname=name, pep3147=True,
+                    recursive=True, return_gocode=False, return_deps=True,
+                    ignore=ignore)
       if name.endswith('.__init__'):
         name = name.rpartition('.__init__')[0]
-        main(stream=open(imp_obj.script), modname=name, pep3147=True, recursive=True, return_result=False, ignore=ignore)
+        result = main(stream=open(imp_obj.script), modname=name, pep3147=True,
+                      recursive=True, return_gocode=False, return_deps=True,
+                      ignore=ignore)
+      yield result['deps']
 
 
 def _transpile(script, modname, imports, visitor, mod_block):
@@ -149,7 +154,7 @@ def _transpile(script, modname, imports, visitor, mod_block):
   return file_buffer
 
 
-def main(stream=None, modname=None, pep3147=False, recursive=False, return_result=True, ignore=None):
+def main(stream=None, modname=None, pep3147=False, recursive=False, return_gocode=True, ignore=None, return_deps=False):
   ignore = ignore or set()
   ignore.add(modname)
   script = os.path.abspath(stream.name)
@@ -163,16 +168,17 @@ def main(stream=None, modname=None, pep3147=False, recursive=False, return_resul
   will_refresh = should_refresh(stream, script, modname)
 
   deps, import_objects = _collect_deps(script, modname, pep3147_folders, from_cache=(not will_refresh))
-  imports = ''.join('\t_ "' + _package_name(name) + '"\n' for name in deps)
+  deps = set(deps)
+  imports = ''.join('\t// _ "' + _package_name(name) + '"\n' for name in deps)
 
-  if will_refresh or return_result:
+  if will_refresh or return_gocode:
     visitor, mod_block = _parse_and_visit(stream, script, modname)
     file_buffer = _transpile(script, modname, imports, visitor, mod_block)
   else:
     file_buffer = None
 
   if recursive:
-    _recursively_transpile(import_objects, ignore=ignore)
+    transitive_deps = _recursively_transpile(import_objects, ignore=ignore)
 
   if pep3147:
     new_gopath = pep3147_folders['gopath_folder']
@@ -186,10 +192,14 @@ def main(stream=None, modname=None, pep3147=False, recursive=False, return_resul
         transpiled_file.write(file_buffer.read())
       set_checksum(stream, script, modname)
 
-  if return_result:
+  result = {}
+  if return_gocode:
     assert file_buffer, "Wrong logic paths. 'file_buffer' should be available here!"
     file_buffer.seek(0)
-    return file_buffer.read()
+    result['gocode'] = file_buffer.read()
+  if return_deps:
+    result['deps'] = frozenset(deps.union(*transitive_deps))
+  return result
 
 
 def _package_name(modname):

--- a/grumpy-tools-src/grumpy_tools/grumprun.py
+++ b/grumpy-tools-src/grumpy_tools/grumprun.py
@@ -111,11 +111,12 @@ def main(stream=None, modname=None, pep3147=False, clean_tempfolder=True):
 
     # Compile the dummy script to Go using grumpc.
     with open(os.path.join(mod_dir, 'module.go'), 'w+') as dummy_file:
-      transpiled = grumpc.main(stream, modname=modname, pep3147=True, recursive=True)
+      result = grumpc.main(stream, modname=modname, pep3147=True, recursive=True, return_deps=True)
+      transpiled, deps = result['gocode'], result['deps']
       dummy_file.write(transpiled)
 
     # Make sure traceback is available in all Python binaries.
-    names = set(['traceback'])
+    names = sorted(set(['traceback']).union(deps))
     go_main = os.path.join(workdir, 'main.go')
     package = _package_name(modname)
     imports = ''.join('\t_ "' + _package_name(name) + '"\n' for name in names)


### PR DESCRIPTION
On Python the circular imports are usually handled by issuing it inside the function needing it.

module_A.function_one needs module_B.function_one, but module_B.method_two can need module_A.helper_two, that is evaluated on run time. This makes the A -> B -> A work by letting the B -> be lazy.

However Go does not allow it. The solution was to bubble up all the imports to the main.go, as it was before the PEP-3147 (`__pycache__`) support got added.

This is needed, e.g., by zipfile.py that imports shutil.py that conditionally imports zipfile.py