### PR TITLE
Delve debug on `grumpy run --go-action debug ... `

### DIFF
--- a/grumpy-tools-src/grumpy_tools/cli.py
+++ b/grumpy-tools-src/grumpy_tools/cli.py
@@ -56,9 +56,11 @@ def transpile(script=None, modname=None, pep3147=False):
 @click.argument('file', required=False, type=click.File('rb'))
 @click.option('-c', '--cmd', help='Program passed in as string')
 @click.option('-m', '-modname', '--modname', help='Run run library module as a script')
+@click.option('--go-action', default='run', type=click.Choice(['run', 'build', 'debug']),
+              help='Action of the Go compilation')
 @click.option('--keep-main', is_flag=True,
               help='Do not clear the temporary folder containing the transpilation result of main script')
-def run(file=None, cmd=None, modname=None, keep_main=False, pep3147=True):
+def run(file=None, cmd=None, modname=None, keep_main=False, pep3147=True, go_action='run'):
     _ensure_gopath()
 
     if modname:
@@ -81,7 +83,8 @@ def run(file=None, cmd=None, modname=None, keep_main=False, pep3147=True):
         stream.seek(0)
         stream.name = '__main__.py'
 
-    result = grumprun.main(stream=stream, modname=modname, pep3147=pep3147, clean_tempfolder=(not keep_main))
+    result = grumprun.main(stream=stream, modname=modname, pep3147=pep3147,
+                           clean_tempfolder=(not keep_main), go_action=go_action)
     sys.exit(result)
 
 

--- a/grumpy-tools-src/grumpy_tools/grumprun.py
+++ b/grumpy-tools-src/grumpy_tools/grumprun.py
@@ -52,7 +52,7 @@ func main() {
 """)
 
 
-def main(stream=None, modname=None, pep3147=False, clean_tempfolder=True):
+def main(stream=None, modname=None, pep3147=False, clean_tempfolder=True, go_action='run'):
   assert pep3147, 'It is no longer optional'
   assert (stream is None and modname) or (stream.name and not modname)
 
@@ -122,8 +122,16 @@ def main(stream=None, modname=None, pep3147=False, clean_tempfolder=True):
     with open(go_main, 'w') as f:
       f.write(module_tmpl.substitute(package=package, imports=imports))
     logger.info('`go run` GOPATH=%s', os.environ['GOPATH'])
-    logger.debug('Starting subprocess: `go run %s`', go_main)
-    return subprocess.Popen('go run ' + go_main, shell=True).wait()
+    if go_action == 'run':
+      subprocess_cmd = 'go run ' + go_main
+    elif go_action == 'build':
+      subprocess_cmd = 'go build ' + go_main
+    elif go_action == 'debug':
+      subprocess_cmd = 'dlv debug --listen=:2345 --log ' + go_main
+    else:
+      raise NotImplementedError('Go action "%s" not implemented' % go_action)
+    logger.debug('Starting subprocess: `%s`', subprocess_cmd)
+    return subprocess.Popen(subprocess_cmd, shell=True).wait()
   finally:
     if 'pep3147_folders' in locals():
       if clean_tempfolder:


### PR DESCRIPTION
Delve debug on `grumpy run --go-action debug ... `
And `go build` instead of `run` on `grumpy run --go-action build`

Probable is a better CLI API to have separate commands for "run" and
"build", but is more code on an already clumsy function.

Should be refactored later.
And TODO: Add docs about needing to install Delve (`dlv`) Go debugger.