### PR TITLE
add c variant for old str formatting

### DIFF
--- a/grumpy-runtime-src/runtime/str.go
+++ b/grumpy-runtime-src/runtime/str.go
@@ -1182,12 +1182,12 @@ func strMod(f *Frame, v, args *Object) (*Object, *BaseException) {
 			}
 			buf.WriteString(val)
 		case "c":
-		    if value.isInstance(IntType) {
-		        val = string(toIntUnsafe(value).Value())
-		    } else {
-		        val = toStrUnsafe(value).Value()
-		    }
-		    buf.WriteString(val)
+			if value.isInstance(IntType) {
+				val = string(toIntUnsafe(value).Value())
+			} else {
+				val = toStrUnsafe(value).Value()
+			}
+			buf.WriteString(val)
 		case "%":
 			val = "%"
 			if fieldWidth > 0 {

--- a/grumpy-runtime-src/runtime/str.go
+++ b/grumpy-runtime-src/runtime/str.go
@@ -1181,6 +1181,13 @@ func strMod(f *Frame, v, args *Object) (*Object, *BaseException) {
 				val = strLeftPad(val, fieldWidth, fillchar)
 			}
 			buf.WriteString(val)
+		case "c":
+		    if value.isInstance(IntType) {
+		        val = string(toIntUnsafe(value).Value())
+		    } else {
+		        val = toStrUnsafe(value).Value()
+		    }
+		    buf.WriteString(val)
 		case "%":
 			val = "%"
 			if fieldWidth > 0 {

--- a/grumpy-runtime-src/testing/str_test.py
+++ b/grumpy-runtime-src/testing/str_test.py
@@ -369,3 +369,6 @@ assert '3'.zfill(LongIntType()) == '03'
 assert '%o' % 8 == '10'
 assert '%o' % -8 == '-10'
 assert '%o %o' % (8, -8) == '10 -10'
+
+assert '%c' % 107 == 'k'
+assert '%c' % 'k' == 'k'


### PR DESCRIPTION
Its important for example for: 
`print(datetime.now())`
And may be checked in this way:
`"%c" % 107 # gives letter 'k'`
and this:
`"%c" % "k" # gives letter 'k' too`