### PR TITLE
Install grumpy-tools before building grumpy-runtime

### DIFF
--- a/grumpy-runtime-src/MANIFEST.in
+++ b/grumpy-runtime-src/MANIFEST.in
@@ -8,3 +8,5 @@ global-exclude *.egg-info/*
 global-exclude *__pycache__*
 
 recursive-exclude grumpy-tools-src *.go
+
+include pyproject.toml

--- a/grumpy-runtime-src/Makefile
+++ b/grumpy-runtime-src/Makefile
@@ -50,8 +50,12 @@ PY_DIR := build/lib/python2.7/site-packages
 PY_INSTALL_DIR := $(shell $(PYTHON) -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 
 export GOPATH := $(ROOT_DIR)/build
-export PYTHONPATH := $(ROOT_DIR)/$(PY_DIR)
 export PATH := $(ROOT_DIR)/build/bin:$(PATH)
+ifndef PYTHONPATH
+  export PYTHONPATH := $(ROOT_DIR)/$(PY_DIR)
+else
+  export PYTHONPATH := $(PYTHONPATH):$(ROOT_DIR)/$(PY_DIR)
+endif
 
 GOPATH_PY_ROOT := $(GOPATH)/src/__python__
 

--- a/grumpy-runtime-src/pyproject.toml
+++ b/grumpy-runtime-src/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["grumpy-tools > 0.2.2"]

--- a/grumpy-runtime-src/pyproject.toml
+++ b/grumpy-runtime-src/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["grumpy-tools > 0.2.2"]
+requires = ["setuptools", "wheel", "grumpy-tools>0.2.2"]


### PR DESCRIPTION
`pip2 install grumpy-runtime` fails with the ERROR
https://github.com/grumpyhome/grumpy/issues/113#issuecomment-521527773
because it relies on `grumpy-tools`.

`grumpy-tools` packages is specified in `setup.py` as a
dependency, and it doesn't work, because for the build process to
succeed, the dependency should already exist at the time `setup.py`
is executed.

The official workaround is `pyproject.toml` from PEP-518
https://github.com/pypa/pip/issues/2381