### PR TITLE
Fix travis ci with osx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       language: go
       go: 1.10.x
       env: OSX_PYTHON=2.7
-      install: brew upgrade python@2
+      install: HOMEBREW_NO_AUTO_UPDATE=1 brew reinstall python@2
 
 install:
   - |


### PR DESCRIPTION
Seems travis ci have issues with macOS and brew, and these PRs is blocked by this:
- https://github.com/grumpyhome/grumpy/pull/144
- https://github.com/grumpyhome/grumpy/pull/145

This PR is a workaround for do not block by it before traivs's stuff fixed it, from: https://travis-ci.community/t/syntax-error-unexpected-keyword-rescue-expecting-keyword-end-in-homebrew/5623/2