### PR TITLE
Makefile: Try to update pylint to fix Travis failure

### DIFF
--- a/grumpy-runtime-src/Makefile
+++ b/grumpy-runtime-src/Makefile
@@ -250,7 +250,7 @@ golint: $(GOLINT_BIN)
 # Instead build pylint from source. Dependencies will be fetched by distutils.
 $(PYLINT_BIN):
 	@mkdir -p build/third_party
-	@cd build/third_party && curl -sL https://pypi.io/packages/source/p/pylint/pylint-1.6.4.tar.gz | tar -zx
+	@cd build/third_party && curl -sL https://pypi.io/packages/source/p/pylint/pylint-2.6.0.tar.gz | tar -zx
 	@cd build/third_party/pylint-1.6.4 && $(PYTHON) setup.py install --prefix $(ROOT_DIR)/build
 
 pylint: $(PYLINT_BIN) $(COMPILER_SRCS) $(PYTHONPARSER_SRCS) $(TOOL_BINS)


### PR DESCRIPTION
I would move all external dependencies to `requirements.txt`, but for now fixing tests would be awesome.