### PR TITLE
setup.py: Separate description for tools and runtime

### DIFF
--- a/grumpy-runtime-src/setup.py
+++ b/grumpy-runtime-src/setup.py
@@ -47,7 +47,7 @@ if needs_pytest:
 
 COMMON_OPTIONS = dict(
     version='0.3.0',
-    description="Grumpy Runtime & Transpiler",
+    description="Grumpy (Python to Go Transpiler) Runtime",
     long_description=readme,
     author="Dylan Trotter et al.",
     maintainer="Alan Justino et al.",

--- a/grumpy-tools-src/setup.py
+++ b/grumpy-tools-src/setup.py
@@ -54,7 +54,7 @@ if needs_pytest:
 
 COMMON_OPTIONS = dict(
     version='0.3.0',
-    description="Grumpy Runtime & Transpiler",
+    description="Grumpy (Python to Go Transpiler) Tools",
     long_description=readme,
     author="Dylan Trotter et al.",
     maintainer="Alan Justino et al.",


### PR DESCRIPTION
Another non-code fix.

I am not sure if the `runtime` is not included in `tools` package. Looks like it is packed as data, but not probably not installed as something to be imported from Python code. I am also not sure why `runtime` is packed for PyPI if it is only usable by generated Go code.